### PR TITLE
Let bffile support Java 8

### DIFF
--- a/src/bffile/_java_stuff.py
+++ b/src/bffile/_java_stuff.py
@@ -32,7 +32,8 @@ if (coord := os.getenv("BIOFORMATS_VERSION", None)) is not None:
         MAVEN_COORDINATE = coord
 
 scyjava.config.endpoints.append(MAVEN_COORDINATE)
-scyjava.config.endpoints.append("ch.qos.logback:logback-classic")
+# NB: logback 1.3.x is the last version with Java 8 support!
+scyjava.config.endpoints.append("ch.qos.logback:logback-classic:1.3.15")
 
 # #################################### LOGGING ####################################
 


### PR DESCRIPTION
The logback project moved on from Java 8, setting Java 11 as minimum in later versions. While Java 8 is a very old Java, the Bio-Formats library does still work with Java 8 otherwise, so it seems a shame to drop support when we can just set the logback version accordingly to let Java 8 work here also.
